### PR TITLE
Blinky demo app on 8-bit AVR MCUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # clion
 .idea/
 cmake-build-*
+subprojects/*/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,47 @@
+# Opinionated fork of compile-time-init for AVR projects
+
+Key changes:
+
+- Cross-compile the example projects with Meson build system;
+- Toolchain and 3rd party dependency management with Meson's WarpDB;
+- AVR chipset support
+- Compile-time logging support on 8-bit MCUs (`unsigned long -> unsigned 32-bit integer`)
+
+## Quick start
+
+1. Edit the path to the AVR gcc v12.0 toolchain in `avr-cross.ini`.
+
+2. Install the build system.
+
+```bash
+python3 -m pip install meson ninja
+```
+
+3. Resolve build dependencies, and setup the build directory.
+```bash
+meson setup --cross-file=avr-cross.ini --buildtype=release build/
+```
+
+4. Compile to ELF file (Linker script not required.)
+```bash
+ninja -C build/ all
+```
+
+5. (Optional): convert the ELF format to ihex format
+```bash
+ninja -C build/ hex
+```
+
+6. Upload the ihex file to Arduino UNO
+```bash
+ninja -C build/ flash
+```
+
+7. (Not yet implemented) Write a Python script `cib_serial_monitor.py` that
+   decodes the incoming streams from the serial port to formatted log messages.
+   With/without logging levels.
+
+---
 # *cib* - Compile-time Initialization and Build
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)

--- a/avr-cross.ini
+++ b/avr-cross.ini
@@ -1,0 +1,45 @@
+[constants]
+avr_prefix = '/opt/avr-gcc'
+avr_toolchain_bin = avr_prefix / 'bin'
+avr_toolchain_prefix = avr_toolchain_bin / 'avr-'
+avr_specs = avr_prefix / 'avr/lib/gcc/avr/12.2.0/device-specs/specs-atmega328p'
+f_cpu = '16000000L'
+
+mcu_args = [
+    '-mmcu=atmega328p',
+    '-specs=' + avr_specs,
+    '-DF_CPU=' + f_cpu]
+
+compile_args = [
+    '-fno-permissive',
+    '-ffunction-sections',
+    '-fdata-sections']
+
+[binaries]
+c = [avr_toolchain_prefix + 'gcc']
+
+cpp = [avr_toolchain_prefix + 'g++']
+
+#ar = avr_toolchain_prefix + 'ar'
+ranlib = avr_toolchain_prefix + 'ranlib'
+strip = avr_toolchain_prefix + 'strip'
+
+[built-in options]
+b_lto=true
+b_staticpic=false
+b_rtti=false
+cpp_eh=none
+cpp_args = mcu_args + compile_args + ['-fno-threadsafe-statics']
+c_args = mcu_args + compile_args
+cpp_link_args = mcu_args + ['-Wl,--gc-sections']
+
+[host_machine]
+system = 'avr'
+cpu_family = 'avr'
+cpu = 'avr'
+endian = 'little'
+
+[properties]
+variant = 'standard'
+objcopy_exe = avr_prefix / 'bin/avr-objcopy'
+avrdude_conf = '/etc/avrdude.conf'

--- a/examples/blinky/blink.hpp
+++ b/examples/blinky/blink.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "config.hpp"
+#include "core.hpp"
+#include "interfaces.hpp"
+
+#include <cib/cib.hpp>
+#include <log/log.hpp>
+
+#include <Arduino.h>
+
+template <uint8_t led_pin> struct blink {
+    static inline bool volatile is_interrupted = false;
+
+    constexpr static auto set_pin =
+        flow::action("set_pin"_sc, []() { ::pinMode(led_pin, OUTPUT); });
+
+    constexpr static auto config = cib::config(                        //
+        cib::extend<RuntimeInit>(core_init::disable_usart >> set_pin), //
+        cib::extend<OnTimerInterrupt>([]() {
+            constexpr auto duration_steps =
+                blink_interval_ms / timer_interrupt_internal_ms;
+            static uint8_t step = 0;
+            static_assert(std::log2(duration_steps) <= sizeof(step) * 8,
+                          "Need more than bits to implement delay()");
+            static_assert(std::log2(duration_steps) >
+                              max(0, int(sizeof(step)) - 1) * 8,
+                          "Wasteful compute");
+            if (++step < duration_steps) {
+                return;
+            }
+            step = 0;
+            is_interrupted = true;
+        }), //
+        cib::extend<MainLoop>([]() {
+            static uint8_t state = HIGH;
+
+            if (!is_interrupted) {
+                return;
+            }
+
+            is_interrupted = false;
+            digitalWrite(led_pin, state);
+            CIB_INFO("LED {:02d} = {:02d}!", led_pin, state);
+            state = !state;
+        }) //
+    );
+};

--- a/examples/blinky/config.hpp
+++ b/examples/blinky/config.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+constexpr auto timer_interrupt_internal_ms = 10UL;
+constexpr auto blink_interval_ms = 1'000UL;

--- a/examples/blinky/core.hpp
+++ b/examples/blinky/core.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "config.hpp"
+#include "interfaces.hpp"
+
+#include <cib/cib.hpp>
+
+#include <wiring_private.h>
+
+template <uint16_t factor> constexpr uint8_t prescalerRegisterValue() {
+    static_assert(factor == 8 || factor == 64 || factor == 256 ||
+                  factor == 1024);
+    switch (factor) {
+    case 1024:
+        return (1 << CS02) | (1 << CS00);
+    case 256:
+        return (1 << CS02);
+    case 64:
+        return (1 << CS01) | (1 << CS00);
+    case 8:
+        return (1 << CS01);
+    default:
+        return 0;
+    }
+}
+
+template <uint16_t prescaler_value, uint32_t time_interval_ms>
+constexpr uint8_t overflowRegisterValue() {
+    constexpr uint32_t clock_frequency_kHz = 16'000;
+    constexpr uint32_t overflow_value =
+        clock_frequency_kHz * time_interval_ms / prescaler_value - 1;
+    static_assert(
+        overflow_value < 255,
+        "Overflow register value > 255; insufficient clock prescaler value?");
+    return static_cast<uint8_t>(overflow_value);
+}
+static_assert(overflowRegisterValue<64, 1>() == 0xF9);
+
+struct core_init {
+    constexpr static auto timer0_init = flow::action("TimerInit"_sc, []() {
+        constexpr auto prescaler = 1024UL;
+
+        cli();
+        TCCR0A = TCCR0A | (1 << WGM01); // Set the CTC mode
+        OCR0A = overflowRegisterValue<
+            prescaler, timer_interrupt_internal_ms>(); // Set the value for 1ms
+        TIMSK0 = TIMSK0 | (1 << OCIE0A); // Set the interrupt request
+        TCCR0B =
+            TCCR0B |
+            prescalerRegisterValue<prescaler>(); // Set the prescale 1/64 clock
+        sei();                                   // Enable interrupt
+    });
+
+    constexpr static auto disable_usart = flow::action("DisableUSART"_sc, []() {
+#if defined(UCSRB)
+        UCSRB = 0;
+#elif defined(UCSR0B)
+        UCSR0B = 0;
+#endif
+    });
+
+    constexpr static auto config = cib::config(cib::extend<RuntimeInit>(
+        core_init::timer0_init >> core_init::disable_usart));
+};

--- a/examples/blinky/interfaces.hpp
+++ b/examples/blinky/interfaces.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <cib/cib.hpp>
+class RuntimeInit : public flow::service<> {};
+class OnTimerInterrupt : public cib::callback_meta<> {};
+class MainLoop : public cib::callback_meta<> {};

--- a/examples/blinky/log_over_uart.hpp
+++ b/examples/blinky/log_over_uart.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <cib/cib.hpp>
+#include <log/catalog/catalog.hpp>
+
+#include <Arduino.h>
+
+namespace serial_logger {
+struct config {
+    struct {
+        template <logging::level Level, typename FilenameStringType,
+                  typename LineNumberType, typename MsgType>
+        auto log(FilenameStringType, LineNumberType,
+                 MsgType const &msg) -> void {
+            using Message = message<Level, MsgType>;
+            uint32_t const msg_id = catalog<Message>();
+
+            // Assume number of messages < 256.
+            Serial.write(static_cast<uint8_t>(msg_id & 0xff));
+
+            msg.args.apply([](auto... args) { logArgs(args...); });
+        }
+
+        template <typename... Args>
+        static void logArgs(uint8_t const t, Args &&...args) {
+            Serial.write(t);
+            logArgs(args...);
+        }
+
+        static void logArgs() {}
+    } logger;
+
+    [[noreturn]] static auto terminate() -> void {
+        // terminate in some way
+    }
+};
+} // namespace serial_logger
+
+template <> inline auto logging::config<> = serial_logger::config{};

--- a/examples/blinky/main.cpp
+++ b/examples/blinky/main.cpp
@@ -1,0 +1,34 @@
+
+#include <cmath>
+
+// <cmath> should be included before <Arduino.h> to avoid the C-macros abs()
+#include "blink.hpp"
+#include "core.hpp"
+#include "log_over_uart.hpp"
+#include "serial.hpp"
+
+struct registered_interfaces {
+    constexpr static auto config =
+        cib::config(cib::exports<RuntimeInit>, cib::exports<OnTimerInterrupt>,
+                    cib::exports<MainLoop>);
+};
+
+struct project {
+    constexpr static auto config =
+        cib::components<registered_interfaces, core_init, serial_init,
+                        blink<13>>;
+};
+
+cib::nexus<project> nexus{};
+
+ISR(TIMER0_COMPA_vect) { nexus.service<OnTimerInterrupt>(); }
+
+int main() {
+    nexus.service<RuntimeInit>();
+
+    for (;;) {
+        nexus.service<MainLoop>();
+    }
+
+    return 0;
+}

--- a/examples/blinky/meson.build
+++ b/examples/blinky/meson.build
@@ -1,0 +1,93 @@
+arduinocore_proj = subproject('arduinocore-avr')
+
+blinky_lib = static_library('blinky',
+    sources: [
+        'main.cpp',
+    ],
+    dependencies: [
+        cib_dep,
+        # avr-ar does not support fat object files, why?
+        arduinocore_proj.get_variable('arduinocore_dep'),
+    ],
+)
+
+python_exe = find_program('python3')
+
+main_sym = custom_target('main.undefined_symbols.txt',
+    output: 'main.undefined_symbols.txt',
+    input: [
+        # There should be just one object file: main.o
+        blinky_lib,
+    ],
+    command: [
+        'nm',
+        '-uC',
+        '@INPUT@'
+    ],
+    capture: true,
+)
+
+logger_stub_bin = custom_target('logger_stub.[cpp|xml]',
+    output: [
+        'logger_stub.cpp',
+        'logger_stub.json',
+        'logger_stub.xml',
+    ],
+    input: [
+        # There should be just one object file: main.o
+        main_sym,
+    ],
+    command: [
+        python_exe,
+        gen_str_catalog_py,
+        '@INPUT0@',
+        '@OUTPUT@',
+    ],
+    build_by_default: true,
+)
+
+blinky_exe = executable('blinky',
+    sources: [
+        logger_stub_bin[0],
+    ],
+    link_with: blinky_lib,
+    dependencies: [
+        cib_dep,
+        # avr-ar does not support fat object files, why?
+        arduinocore_proj.get_variable('arduinocore_dep'),
+    ],
+)
+
+blinky_hex = custom_target('blinky.hex',
+    input: blinky_exe,
+    output: 'blinky.hex',
+    command: [
+        meson.get_cross_property('objcopy_exe'),
+        '-O', 'ihex',
+        '-R', '.eeprom',
+        '@INPUT@',
+        '@OUTPUT@',
+    ],
+    build_by_default: false,
+)
+
+avrdude_exe = find_program('avrdude')
+avrdude_conf = files(meson.get_cross_property('avrdude_conf'))
+flash_log = custom_target('flash.log',
+    input: blinky_hex,
+    output: 'flash.log',
+    command: [
+        avrdude_exe, '-q', '-V',
+        '-p', 'atmega328p',
+        '-C', avrdude_conf,
+        '-D', '-c', 'arduino',
+        '-b', '115200',
+        '-P', '/dev/ttyACM0',
+        '-U', 'flash:w:@INPUT@:i',
+    ],
+    capture: true,
+)
+
+alias_target('stub', logger_stub_bin)
+alias_target('hex', blinky_hex)
+alias_target('flash', flash_log)

--- a/examples/blinky/serial.hpp
+++ b/examples/blinky/serial.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "interfaces.hpp"
+
+#include <cib/cib.hpp>
+
+#include <Arduino.h>
+
+struct serial_init {
+    constexpr static auto enable_uart = flow::action("SerialInit"_sc, []() {
+        Serial.begin(115'200);
+        while (!Serial)
+            ;
+    });
+
+    constexpr static auto config = cib::config(cib::extend<RuntimeInit>(
+        core_init::disable_usart >> serial_init::enable_uart));
+};

--- a/examples/hello_world/meson.build
+++ b/examples/hello_world/meson.build
@@ -1,0 +1,15 @@
+if not meson.is_cross_build()
+
+hello_world = executable('hello_world',
+    include_directories: '.',
+    sources: [
+        'dont_panic.cpp',
+        'main.cpp',
+    ],
+    dependencies: [
+        cib_dep,
+        fmt_dep,
+    ],
+)
+
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,38 @@
+project('cib', 'cpp',
+    default_options: [
+        'cpp_std=c++20'
+    ]
+)
+
+stdx_dep = subproject('stdx').get_variable('stdx_dep')
+conc_dep = subproject('conc').get_variable('conc_dep')
+mp11_dep = subproject('boost-mp11').get_variable('mp11_dep')
+if meson.is_cross_build()
+    avr_stdcpp_dep = subproject('avr-libstdcpp').get_variable('avr_stdcpp_dep')
+else
+    avr_stdcpp_dep = []
+    fmt_dep = declare_dependency(
+    compile_args: 
+            # Eliminates include <locale>
+            '-DFMT_STATIC_THOUSANDS_SEPARATOR',
+    dependencies: subproject('fmt').get_variable('fmt_header_only_dep'),
+    )
+
+endif
+
+cib_dep = declare_dependency(
+    include_directories: 'include',
+    compile_args: [
+        '-Wno-missing-braces',
+    ],
+    dependencies: [
+        stdx_dep,
+        conc_dep,
+        mp11_dep,
+        avr_stdcpp_dep,
+    ],
+)
+
+subdir('tools')
+subdir('examples/hello_world')
+subdir('examples/blinky')

--- a/subprojects/arduinocore-avr.wrap
+++ b/subprojects/arduinocore-avr.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = avr
+source_url = http://downloads.arduino.cc/cores/avr-1.8.2.tar.bz2
+source_filename = avr-1.8.2.tar.bz2
+source_hash = 6213d41c6e91a75ac931527da5b10f2dbe0140c8cc1dd41b06cd4e78b943f41b
+patch_url = https://wrapdb.mesonbuild.com/v2/arduinocore-avr_1.8.2-1/get_patch
+patch_filename = arduinocore-avr-1.8.2-1-wrap.zip
+patch_hash = 32d9bbf08fd0c5f10be5ede1355af7c60e37d0cb759e903bf5c37a8047744faa
+

--- a/subprojects/avr-libstdcpp.wrap
+++ b/subprojects/avr-libstdcpp.wrap
@@ -1,0 +1,10 @@
+[wrap-git]
+directory = avr-libstdcpp
+url = https://github.com/modm-io/avr-libstdcpp.git
+revision = 9d10e0047011f4c1e6ef4dbf76aca5e9a340a6f8
+depth = 1
+patch_directory = avr-libstdcpp
+
+[provide]
+avr_stdcpp = avr_stdcpp_dep
+

--- a/subprojects/boost-mp11.wrap
+++ b/subprojects/boost-mp11.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = mp11-boost-1.83.0
+source_url = https://github.com/boostorg/mp11/archive/refs/tags/boost-1.83.0.tar.gz
+source_filename = boost-1.83.0.tar.gz
+source_hash = 5b0a4397ff386e0b94e66f18ce6d3dbc9230ace40448bbc79a3963c166c326d1
+patch_directory = mp11

--- a/subprojects/conc.wrap
+++ b/subprojects/conc.wrap
@@ -1,0 +1,9 @@
+[wrap-git]
+directory = cpp-baremetal-concurrency
+url = https://github.com/intel/cpp-baremetal-concurrency.git
+revision = fd756b8cb2d6a098509eeed8bde1fe3459a108a0
+depth = 1
+patch_directory = conc
+
+[provide]
+conc = conc_dep

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = fmt-9.1.0
+source_url = https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz
+source_filename = fmt-9.1.0.tar.gz
+source_hash = 5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2
+patch_filename = fmt_9.1.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_9.1.0-1/get_patch
+patch_hash = 4557b9ba87b3eb63694ed9b21d1a2117d4a97ca56b91085b10288e9a5294adf8
+wrapdb_version = 9.1.0-1
+
+[provide]
+fmt = fmt_dep

--- a/subprojects/packagefiles/avr-libstdcpp/meson.build
+++ b/subprojects/packagefiles/avr-libstdcpp/meson.build
@@ -1,0 +1,5 @@
+project('avr-libstdcpp', 'cpp')
+
+avr_stdcpp_dep = declare_dependency(
+    include_directories: 'include',
+)

--- a/subprojects/packagefiles/conc/meson.build
+++ b/subprojects/packagefiles/conc/meson.build
@@ -1,0 +1,5 @@
+project('cpp-baremetal-concurrency', 'cpp')
+
+conc_dep = declare_dependency(
+    include_directories: 'include',
+)

--- a/subprojects/packagefiles/mp11/meson.build
+++ b/subprojects/packagefiles/mp11/meson.build
@@ -1,0 +1,5 @@
+project('boost-mp11', 'cpp')
+
+mp11_dep = declare_dependency(
+    include_directories: 'include',
+)

--- a/subprojects/packagefiles/stdx/meson.build
+++ b/subprojects/packagefiles/stdx/meson.build
@@ -1,0 +1,5 @@
+project('cpp-std-extensions', 'cpp')
+
+stdx_dep = declare_dependency(
+    include_directories: 'include',
+)

--- a/subprojects/packagefiles/stdx/relax-tuple-concepts.patch
+++ b/subprojects/packagefiles/stdx/relax-tuple-concepts.patch
@@ -1,0 +1,22 @@
+diff --git a/include/stdx/tuple.hpp b/include/stdx/tuple.hpp
+index 215cb7c..2569987 100644
+--- a/include/stdx/tuple.hpp
++++ b/include/stdx/tuple.hpp
+@@ -351,7 +351,7 @@ struct tuple_impl<std::index_sequence<Is...>, index_function_list<Fs...>, Ts...>
+ 
+   private:
+     template <typename Funcs, typename... Us>
+-        requires(... and std::equality_comparable_with<Ts, Us>)
++        //requires(... and std::equality_comparable_with<Ts, Us>)
+     [[nodiscard]] friend constexpr auto
+     operator==(tuple_impl const &lhs,
+                tuple_impl<std::index_sequence<Is...>, Funcs, Us...> const &rhs)
+@@ -360,7 +360,7 @@ struct tuple_impl<std::index_sequence<Is...>, index_function_list<Fs...>, Ts...>
+     }
+ 
+     template <typename Funcs, typename... Us>
+-        requires(... and std::three_way_comparable_with<Ts, Us>)
++        //requires(... and std::three_way_comparable_with<Ts, Us>)
+     [[nodiscard]] friend constexpr auto operator<=>(
+         tuple_impl const &lhs,
+         tuple_impl<std::index_sequence<Is...>, Funcs, Us...> const &rhs) {

--- a/subprojects/stdx.wrap
+++ b/subprojects/stdx.wrap
@@ -1,0 +1,10 @@
+[wrap-git]
+directory = cpp-std-extensions
+url = https://github.com/intel/cpp-std-extensions.git
+revision = 495e3875999bd4337c9efca2d6ed7c2df0fa374c
+depth = 1
+patch_directory = stdx
+diff_files = stdx/relax-tuple-concepts.patch
+
+[provide]
+stdx = stdx_dep

--- a/tools/gen_str_catalog.py
+++ b/tools/gen_str_catalog.py
@@ -14,11 +14,11 @@ xml_file = sys.argv[4]
 # cust_name = sys.argv[6]
 # bit_mask_files = sys.argv[7:]
 
-catalog_re = re.compile("^.+?(unsigned int catalog<(.+?)>\(\))\s*$")
+catalog_re = re.compile(r"^.+?(unsigned long catalog<(.+?)>\(\))\s*$")
 
 # unsigned int catalog<message<(logging::level)7, sc::lazy_string_format<sc::string_constant<char, (char)102, (char)108, (char)111, (char)119, (char)46, (char)115, (char)116, (char)97, (char)114, (char)116, (char)40, (char)77, (char)101, (char)109, (char)111, (char)114, (char)121, (char)69, (char)114, (char)114, (char)111, (char)114, (char)41>, cib::tuple<> > > >()
 string_re = re.compile(
-    "message<\(logging::level\)(\d+), sc::lazy_string_format<sc::string_constant<char, (.*)>\s*(?:const)?, cib::(?:[a-zA-Z0-9_]+::)*tuple<(.*)>\s*>\s*>"
+    r"message<\(logging::level\)(\d+), sc::lazy_string_format<sc::string_constant<char, (.*)>\s*(?:const)?, cib::(?:[a-zA-Z0-9_]+::)*tuple<(.*)>\s*>\s*>"
 )
 
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,5 @@
+#py = import('python').find_installation()
+python_exe = find_program('python3')
+
+files('gen_str_catalog.py')
+gen_str_catalog_py = meson.current_source_dir() / 'gen_str_catalog.py'


### PR DESCRIPTION
Port the CMake-based build system to mesonbuild. Port the build dependency system from CPM/CMake to Warp/Meson (e.g. C++ constexpr STL support for AVR; Arduino HAL dependencies).

In the blinky app, implement the hardware serial interface to write the CIB formatted logging messages. Modify Timer0 to trigger an interrupt every 10ms. Blink the LED on an interval of 1000ms.

Demonstrate compile-time dependency injection (DI) of hardware components so as to define the device-tree in the main `blinky.cpp` file.

Describe the Meson-based build instructions in README.